### PR TITLE
Skeleton: CMake + FetchHiGHS + no-op algorithm stubs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# mip-heuristics
+
+## Quick Reference
+
+```bash
+# build
+cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)
+
+# test
+ctest --test-dir build -j$(nproc)
+
+# run highs directly
+./build/bin/highs [model.mps]
+```
+
+## Git
+
+- Never commit directly to `main`. Always feature branches.
+- Linear history only (squash-merge or rebase-merge).
+
+## Workflow: Plan → Grind
+
+Every task has two phases. Do not skip planning.
+
+### Plan (default)
+
+When given a task, **plan first**: investigate the code, propose an approach,
+discuss with the user. Wait for approval before implementing (e.g. "grind", "go", "do it").
+
+### Grind (on approval)
+
+Execute autonomously. Build, test, fix, repeat until green.
+Self-review, then fullgate: branch, PR, sync main, push.
+Progress lives in files and git — not in your context window.
+
+Only pause and ask a human when:
+- A fix requires changing the public API or architecture
+- You discover a bug in unrelated code you shouldn't touch
+- You're stuck after multiple failed attempts
+
+### Fullgate
+
+Also runs standalone when user says **"fullgate"**:
+branch → PR → sync (merge main **into** feature branch) → tests → docs →
+push → review → build → test → push fixes → squash-merge → delete branch
+
+### Claiming Work (GitHub)
+
+- `gh issue edit <N> --add-label agent-wip` when starting on an issue or PR
+- Check for `agent-wip` label before picking up work
+- Remove label and close/merge when done
+
+### Teams
+
+For independent sub-tasks, launch a team. Each teammate works in its own
+worktree. Lead integrates: merge, resolve conflicts, build/test the result.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.25)
+project(mip-heuristics LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+include(cmake/FetchHiGHS.cmake)
+
+add_library(mip_heuristics OBJECT
+    src/fpr.cpp
+    src/local_mip.cpp
+    src/scylla_fpr.cpp
+)
+target_include_directories(mip_heuristics PRIVATE ${highs_SOURCE_DIR}/highs src)
+
+target_sources(highs PRIVATE $<TARGET_OBJECTS:mip_heuristics>)
+target_include_directories(highs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# --- Tests ---
+set(BUILD_TESTING ON CACHE BOOL "" FORCE)
+include(FetchContent)
+FetchContent_Declare(Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.7.1
+)
+FetchContent_MakeAvailable(Catch2)
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+include(CTest)
+include(Catch)
+
+add_executable(mip_heuristics_tests tests/test_basic.cpp)
+target_include_directories(mip_heuristics_tests PRIVATE ${highs_SOURCE_DIR}/highs)
+target_link_libraries(mip_heuristics_tests PRIVATE highs Catch2::Catch2WithMain)
+catch_discover_tests(mip_heuristics_tests)

--- a/cmake/FetchHiGHS.cmake
+++ b/cmake/FetchHiGHS.cmake
@@ -1,0 +1,19 @@
+include(FetchContent)
+
+# Disable HiGHS components we don't need
+set(HIGHS_NO_DEFAULT_THREADS ON CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(PDLP OFF CACHE BOOL "" FORCE)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(highs
+    GIT_REPOSITORY https://github.com/ERGO-Code/HiGHS.git
+    GIT_TAG        v1.13.1
+    PATCH_COMMAND ${CMAKE_COMMAND}
+        -DPATCH_DIR=${CMAKE_CURRENT_SOURCE_DIR}/third_party/highs_patch
+        -DSOURCE_DIR=<SOURCE_DIR>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/third_party/highs_patch/apply_patch.cmake
+)
+
+FetchContent_MakeAvailable(highs)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,159 @@
+# Plan: New repo — compile custom primal heuristics into HiGHS
+
+## Context
+
+The standalone mip-heuristics library can't compete with HiGHS on upper bounds due to lack of LP guidance. The algorithms (FPR, LocalMIP, ScyllaFPR) are the real value. This plan creates a new repo where HiGHS is the vessel: we compile our heuristics into HiGHS, producing the standard `highs` binary with extra primal heuristics. The code is structured so the algorithms are easy to read and repurpose — HiGHS maintainers can adopt what they want.
+
+**HiGHS landscape**: Mark Turner has draft branches for `local-mip` (WalkSAT-style 1-opt) and `mt/fix-and-propagate` (one-shot fix+propagate, no repair). Neither is merged or a PR. Our implementations are more mature: FPR adds WalkSAT repair; LocalMIP adds weight decay, restarts, aspiration, lift moves. We build independently and let benchmarks showcase quality.
+
+**Not porting**: FJ (HiGHS already has it, core identical), Diving (redundant inside HiGHS B&B), Thompson Sampling portfolio (less valuable inside B&B).
+
+## Step 0: Repo transition (manual)
+
+- Rename `spoorendonk/mip-heuristics` → `spoorendonk/mip-heuristics-old` on GitHub
+- Rename `~/code/my/mip-heuristics` → `~/code/my/mip-heuristics-old` locally
+- Create new `spoorendonk/mip-heuristics` on GitHub and clone to `~/code/my/mip-heuristics`
+
+The old repo stays as reference during porting.
+
+## Project structure
+
+```
+mip-heuristics/
+  plan.md                        # this plan
+  CMakeLists.txt                 # fetch HiGHS, build patched binary
+  cmake/
+    FetchHiGHS.cmake             # FetchContent + PATCH_COMMAND
+  third_party/highs_patch/
+    apply_patch.cmake             # idempotent string_replace patches (~150 lines)
+    HighsUserHeuristic.h          # injected into HiGHS src/mip/ — thin dispatch layer
+    HighsUserHeuristic.cpp        # calls into our src/ implementations
+  src/                            # OUR CODE — readable, self-contained algorithms
+    fpr.h / fpr.cpp               # Fix-Propagate-Repair with WalkSAT
+    local_mip.h / local_mip.cpp  # LocalMIP tabu search
+    scylla_fpr.h / scylla_fpr.cpp # LP-guided FPR variant
+    common.h                      # shared types/utilities (constraint iteration helpers)
+  tests/
+    test_basic.cpp
+```
+
+Target: HiGHS **v1.13.1** (same as cptp, proven patch compatibility).
+
+**Design principle**: `src/` contains the algorithms in readable form. `third_party/highs_patch/` is the minimal glue. Someone reading `src/fpr.cpp` should understand the algorithm without reading HiGHS internals.
+
+## Patch design (apply_patch.cmake)
+
+Follows cptp pattern: idempotent `string(FIND ...)` + `string(REPLACE ...)`.
+
+### Files patched (3 files, ~30 lines of diff)
+
+| HiGHS file | Change | Purpose |
+|---|---|---|
+| `cmake/sources.cmake` | Add `HighsUserHeuristic.h/cpp` | Register injected files in build |
+| `HighsMipSolverData.cpp` ~L2053 | Add `HighsUserHeuristic::runAtRoot(mipsolver)` after shifting+flush | Run FPR/LocalMIP at root node |
+| `HighsMipSolver.cpp` ~L299 | Add `HighsUserHeuristic::runAtNode(mipsolver)` after RINS/RENS+flush | Run ScyllaFPR during B&B dives |
+
+### HighsUserHeuristic (thin dispatch layer)
+
+```cpp
+class HighsUserHeuristic {
+public:
+    static void runAtRoot(HighsMipSolver& mipsolver);   // FPR, LocalMIP
+    static void runAtNode(HighsMipSolver& mipsolver);   // ScyllaFPR (needs LP sol)
+};
+```
+
+Guards: skip when `mipsolver.submip`.
+
+## Data bridge
+
+Algorithms access HiGHS data directly (no copying):
+
+| What | HiGHS accessor |
+|---|---|
+| Row-major constraints | `mipdata_->ARstart_/ARindex_/ARvalue_` |
+| Column-major constraints | `model_->a_matrix_.start_/index_/value_` |
+| Variable bounds | `mipdata_->domain.col_lower_/col_upper_` |
+| Variable types | `model_->integrality_` |
+| Objective | `model_->col_cost_`, `model_->sense_` |
+| Row bounds | `model_->row_lower_/row_upper_` |
+| Incumbent | `mipdata_->incumbent` |
+| LP solution (Scylla) | `mipdata_->lp.getLpSolver().getSolution().col_value` |
+| Inject solution | `mipdata_->addIncumbent(sol, obj, source)` |
+
+`common.h` provides lightweight iteration helpers for clean algorithm code.
+
+## Heuristics — stepwise porting plan
+
+### Step 1: FPR (Fix-Propagate-Repair)
+- **Source**: `mip-heuristics-old/src/heuristic/fpr/fpr.cpp` (~400 LOC core)
+- **Algorithm**: Rank variables by degree×objective → greedy fix → propagate bounds → WalkSAT repair
+- **LP-free**: Yes. Runs at root before B&B starts.
+- **Key differentiator vs HiGHS `mt/fix-and-propagate`**: WalkSAT repair phase. HiGHS branch gives up on infeasibility; we repair.
+- **Why first**: Smallest, validates entire patch infrastructure.
+
+### Step 2: LocalMIP
+- **Source**: `mip-heuristics-old/src/heuristic/local_mip/local_mip.cpp` (~600 LOC core)
+- **Algorithm**: Tabu search with breakthrough scoring, lift moves, weight smoothing, aspiration
+- **LP-free**: Yes. Needs incumbent to start (naturally runs after FPR finds one).
+- **Key differentiators vs HiGHS `local-mip` branch**: Weight decay, restarts, aspiration criterion, longer tabu tenure, lift moves (vs one-opt), BMS sampling.
+- **Why second**: Strongest algorithm, but depends on incumbent from Step 1.
+
+### Step 3: ScyllaFPR
+- **Source**: `mip-heuristics-old/src/heuristic/scylla/scylla_fpr.cpp` (~100 LOC wrapper)
+- **Algorithm**: FPR but ranks by LP fractionality instead of degree.
+- **LP-dependent**: Yes. Runs during B&B dives when LP solution is available.
+- **Why third**: Trivial once FPR exists (ranking-strategy swap). Demonstrates LP-guided variant.
+
+### Future (not in first pass)
+- FJ improvements (pool-based restarts, configurable stall detection) as small upstream PR
+- Pseudocost diving — skip, redundant inside HiGHS B&B
+
+## Build system
+
+```cmake
+cmake_minimum_required(VERSION 3.25)
+project(mip-heuristics LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 23)
+
+include(cmake/FetchHiGHS.cmake)
+
+add_library(mip_heuristics_impl OBJECT
+    src/fpr.cpp
+    src/local_mip.cpp
+    src/scylla_fpr.cpp
+)
+target_include_directories(mip_heuristics_impl PRIVATE ${highs_SOURCE_DIR}/highs src)
+
+target_sources(highs PRIVATE $<TARGET_OBJECTS:mip_heuristics_impl>)
+target_include_directories(highs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+```
+
+Output: standard `highs` binary at `build/_deps/highs-build/bin/highs`.
+
+## Implementation sequence
+
+1. **Skeleton** — CMake, FetchHiGHS.cmake, empty HighsUserHeuristic (no-op). Verify `highs` builds and runs. Commit plan.md with skeleton.
+2. **Patch wiring** — apply_patch.cmake with root + node dispatch hooks. Verify patch applies, `highs` still works.
+3. **Port FPR** — Rewrite to use HiGHS arrays. Wire into `runAtRoot()`. Test on small MPS.
+4. **Port LocalMIP** — Wire into `runAtRoot()` (after FPR). Test similarly.
+5. **Port ScyllaFPR** — Wire into `runAtNode()`. Test with LP-guided ranking.
+6. **Benchmark** — Patched HiGHS vs vanilla on MIPLIB subset.
+
+## Verification
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)
+./build/_deps/highs-build/bin/highs test.mps
+# verify heuristics fire (addIncumbent prints source on new incumbent)
+```
+
+## Key reference files
+
+- `~/code/my/cptp/cmake/FetchHiGHS.cmake` — FetchContent pattern
+- `~/code/my/cptp/third_party/highs_patch/apply_patch.cmake` — patch script pattern
+- `~/code/my/cptp/build/_deps/highs-src/highs/mip/HighsMipSolver.cpp:260-306` — B&B dive dispatch
+- `~/code/my/cptp/build/_deps/highs-src/highs/mip/HighsMipSolverData.cpp:2045-2055` — root dispatch
+- `~/code/my/mip-heuristics-old/src/heuristic/fpr/fpr.cpp` — FPR to port
+- `~/code/my/mip-heuristics-old/src/heuristic/local_mip/local_mip.cpp` — LocalMIP to port
+- `~/code/my/mip-heuristics-old/src/heuristic/scylla/scylla_fpr.cpp` — ScyllaFPR to port

--- a/src/fpr.cpp
+++ b/src/fpr.cpp
@@ -1,0 +1,2 @@
+#include "fpr.h"
+namespace fpr { void run(HighsMipSolver&) {} }

--- a/src/fpr.h
+++ b/src/fpr.h
@@ -1,0 +1,3 @@
+#pragma once
+class HighsMipSolver;
+namespace fpr { void run(HighsMipSolver& mipsolver); }

--- a/src/local_mip.cpp
+++ b/src/local_mip.cpp
@@ -1,0 +1,2 @@
+#include "local_mip.h"
+namespace local_mip { void run(HighsMipSolver&) {} }

--- a/src/local_mip.h
+++ b/src/local_mip.h
@@ -1,0 +1,3 @@
+#pragma once
+class HighsMipSolver;
+namespace local_mip { void run(HighsMipSolver& mipsolver); }

--- a/src/scylla_fpr.cpp
+++ b/src/scylla_fpr.cpp
@@ -1,0 +1,2 @@
+#include "scylla_fpr.h"
+namespace scylla_fpr { void run(HighsMipSolver&) {} }

--- a/src/scylla_fpr.h
+++ b/src/scylla_fpr.h
@@ -1,0 +1,3 @@
+#pragma once
+class HighsMipSolver;
+namespace scylla_fpr { void run(HighsMipSolver& mipsolver); }

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch_test_macros.hpp>
+#include "Highs.h"
+
+TEST_CASE("Smoke test: solve small MIP", "[basic]") {
+    // min x + y
+    // s.t. x + y >= 1
+    //      x, y in {0, 1}
+    Highs highs;
+    highs.setOptionValue("output_flag", false);
+
+    highs.addVar(0.0, 1.0);
+    highs.addVar(0.0, 1.0);
+    highs.changeColCost(0, 1.0);
+    highs.changeColCost(1, 1.0);
+    highs.changeColIntegrality(0, HighsVarType::kInteger);
+    highs.changeColIntegrality(1, HighsVarType::kInteger);
+
+    HighsInt idx[] = {0, 1};
+    double val[] = {1.0, 1.0};
+    highs.addRow(1.0, kHighsInf, 2, idx, val);
+
+    HighsStatus status = highs.run();
+    REQUIRE(status == HighsStatus::kOk);
+
+    HighsInt sol_status;
+    highs.getInfoValue("primal_solution_status", sol_status);
+    REQUIRE(sol_status == kSolutionStatusFeasible);
+
+    double obj;
+    highs.getInfoValue("objective_function_value", obj);
+    REQUIRE(obj == 1.0);
+}

--- a/third_party/highs_patch/apply_patch.cmake
+++ b/third_party/highs_patch/apply_patch.cmake
@@ -1,0 +1,39 @@
+# Patch script for HiGHS: insert heuristic call sites
+# Called by FetchContent PATCH_COMMAND
+# Idempotent: safe to run multiple times.
+
+# Detect source layout: v1.13+ uses highs/ subdirectory
+if(EXISTS "${SOURCE_DIR}/highs/mip")
+    set(MIP_DIR "${SOURCE_DIR}/highs/mip")
+else()
+    set(MIP_DIR "${SOURCE_DIR}/src/mip")
+endif()
+
+# ── Patch HighsMipSolver.cpp: insert heuristic call sites ──
+file(READ "${MIP_DIR}/HighsMipSolver.cpp" CONTENT)
+
+string(FIND "${CONTENT}" "fpr::run" _found)
+if(_found EQUAL -1)
+    # Add includes at top (after existing includes)
+    string(REPLACE
+      "#include \"mip/HighsMipSolver.h\""
+      "#include \"mip/HighsMipSolver.h\"\n#include \"fpr.h\"\n#include \"local_mip.h\"\n#include \"scylla_fpr.h\""
+      CONTENT "${CONTENT}")
+
+    # Patch A: after feasibilityJump block (pre-root-node, LP-free heuristics)
+    string(REPLACE
+      "    }\n    // End of pre-root-node heuristics"
+      "    }\n    fpr::run(*this);\n    local_mip::run(*this);\n\n    // End of pre-root-node heuristics"
+      CONTENT "${CONTENT}")
+
+    # Patch B: after RINS/RENS block closing brace (B&B dive)
+    string(REPLACE
+      "          }\n\n          mipdata_->heuristics.flushStatistics();"
+      "          }\n          scylla_fpr::run(*this);\n\n          mipdata_->heuristics.flushStatistics();"
+      CONTENT "${CONTENT}")
+
+    file(WRITE "${MIP_DIR}/HighsMipSolver.cpp" "${CONTENT}")
+    message(STATUS "Applied heuristic call site patches to HighsMipSolver.cpp")
+else()
+    message(STATUS "Heuristic patches already applied to HighsMipSolver.cpp, skipping")
+endif()


### PR DESCRIPTION
## Summary
- Fetch HiGHS v1.13.1 via FetchContent with idempotent patch wiring
- Patch `HighsMipSolver.cpp` with call sites for FPR/LocalMIP (pre-root-node) and ScyllaFPR (B&B dive)
- Compile no-op stubs as OBJECT library injected into `highs` target
- Catch2 smoke test verifying HiGHS solves a small MIP

## Test plan
- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)` — builds clean
- [x] `ctest --test-dir build` — 1/1 passed
- [x] `./build/bin/highs --version` — reports v1.13.1
- [x] Patch idempotency verified via clean rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)