### PR TITLE
Port LocalMIP (tabu-search local improvement) into HiGHS

### DIFF
--- a/src/local_mip.cpp
+++ b/src/local_mip.cpp
@@ -198,15 +198,12 @@ void run(HighsMipSolver& mipsolver) {
     double delta = new_val - old_val;
     if (std::abs(delta) < 1e-15) return;
     solution[j] = new_val;
+    lift_dirty[j] = true;
     for (HighsInt p = col_start[j]; p < col_start[j + 1]; ++p) {
       HighsInt i = col_row[p];
       lhs[i] += col_val[p] * delta;
       update_violated(i);
-    }
-    // Invalidate lift cache for neighbors
-    lift_dirty[j] = true;
-    for (HighsInt p = col_start[j]; p < col_start[j + 1]; ++p) {
-      HighsInt i = col_row[p];
+      // Invalidate lift cache for all variables sharing this row
       for (HighsInt k = ARstart[i]; k < ARstart[i + 1]; ++k)
         lift_dirty[ARindex[k]] = true;
     }
@@ -365,14 +362,17 @@ void run(HighsMipSolver& mipsolver) {
       }
 
       double prog = compute_progress_score(c.var_idx, c.new_val);
-      double bon = compute_bonus_score(c.var_idx, c.new_val);
 
-      bool better = false;
-      if (prog > best.score + kViolTol)
-        better = true;
-      else if (prog > best.score - kViolTol && bon > best.bonus)
-        better = true;
-      if (better) best = {c.var_idx, c.new_val, prog, bon};
+      if (prog > best.score + kViolTol) {
+        // Clear winner on progress — compute bonus for future tie-breaking
+        double bon = compute_bonus_score(c.var_idx, c.new_val);
+        best = {c.var_idx, c.new_val, prog, bon};
+      } else if (prog > best.score - kViolTol) {
+        // Tied on progress — break tie with bonus
+        double bon = compute_bonus_score(c.var_idx, c.new_val);
+        if (bon > best.bonus)
+          best = {c.var_idx, c.new_val, prog, bon};
+      }
     }
     return best;
   };


### PR DESCRIPTION
## Summary

- Replaces `local_mip::run()` no-op stub with complete tabu-search local improvement heuristic (~800 LOC)
- Ports all key mechanisms: BMS weighted violation scoring, directional tabu, lift moves (feasible-mode objective optimization), aspiration criterion, breakthrough moves, sat-MTM diversification, easy moves, constraint weight smoothing with geometric decay, activity rebuild, and restart logic
- Adapts all violation/tight-delta/lift-bounds computations for HiGHS ranged rows (`row_lo`/`row_hi`) instead of `ConstraintSense`

## Test plan

- [x] `cmake --build build` compiles cleanly
- [x] `ctest --test-dir build` passes
- [x] `flugpl.mps`: finds optimal solution (1,240,500)
- [x] `blend2.mps`: 24 improving H solutions (143.6 → 77.4)
- [x] `neos-911970.mps`: 6 improving H solutions (1080.4 → 726.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)