### PR TITLE
Port ScyllaFPR (LP-guided FPR) into HiGHS

### DIFF
--- a/src/scylla_fpr.cpp
+++ b/src/scylla_fpr.cpp
@@ -1,7 +1,9 @@
 #include "scylla_fpr.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
+#include <limits>
 #include <random>
 #include <vector>
 
@@ -20,6 +22,7 @@ void run(HighsMipSolver& mipsolver) {
   if (!HighsLpRelaxation::scaledOptimal(lp_status)) return;
 
   const auto& lp_sol = mipdata->lp.getLpSolver().getSolution().col_value;
+  assert(static_cast<HighsInt>(lp_sol.size()) >= model->num_col_);
 
   const auto& ARstart = mipdata->ARstart_;
   const auto& ARindex = mipdata->ARindex_;


### PR DESCRIPTION
## Summary
- LP-guided variant of FPR that runs during B&B dives using the LP relaxation solution
- Ranks integer variables by fractionality (`|lp_val - round(lp_val)|`) instead of `degree × |cost|`
- Uses LP solution as initial values and fix-value hints; falls back to objective-greedy
- Single-attempt design (no retry loop) — called repeatedly by HiGHS B&B dive loop
- Guards on LP optimality; returns early if LP relaxation not available

## Test plan
- [x] `cmake --build build` compiles cleanly
- [x] `ctest --test-dir build` passes
- [x] `blend2.mps` and `neos-911970.mps` solve to optimality with heuristics active

🤖 Generated with [Claude Code](https://claude.com/claude-code)