### PR TITLE
Add HiGHS-style option parameters for custom heuristics

### DIFF
--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -65,3 +65,21 @@ TEST_CASE("Characterization: bell5", "[heuristic][fpr]") {
   highs.getInfoValue("objective_function_value", obj);
   REQUIRE(obj == Catch::Approx(8966406.49152).epsilon(1e-6));
 }
+
+TEST_CASE("Options: disable custom heuristics", "[options]") {
+  Highs highs;
+  highs.setOptionValue("output_flag", false);
+  // Verify options exist and can be set
+  REQUIRE(highs.setOptionValue("mip_heuristic_run_fpr", false) ==
+          HighsStatus::kOk);
+  REQUIRE(highs.setOptionValue("mip_heuristic_run_local_mip", false) ==
+          HighsStatus::kOk);
+  REQUIRE(highs.setOptionValue("mip_heuristic_run_scylla_fpr", false) ==
+          HighsStatus::kOk);
+  // Solve still works with all custom heuristics disabled
+  REQUIRE(highs.readModel(kInstancesDir + "/flugpl.mps") == HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  double obj;
+  highs.getInfoValue("objective_function_value", obj);
+  REQUIRE(obj == Catch::Approx(1201500.0).epsilon(1e-6));
+}

--- a/third_party/highs_patch/apply_patch.cmake
+++ b/third_party/highs_patch/apply_patch.cmake
@@ -1,12 +1,43 @@
-# Patch script for HiGHS: insert heuristic call sites
+# Patch script for HiGHS: insert heuristic call sites and options
 # Called by FetchContent PATCH_COMMAND
 # Idempotent: safe to run multiple times.
 
 # Detect source layout: v1.13+ uses highs/ subdirectory
 if(EXISTS "${SOURCE_DIR}/highs/mip")
     set(MIP_DIR "${SOURCE_DIR}/highs/mip")
+    set(LP_DATA_DIR "${SOURCE_DIR}/highs/lp_data")
 else()
     set(MIP_DIR "${SOURCE_DIR}/src/mip")
+    set(LP_DATA_DIR "${SOURCE_DIR}/src/lp_data")
+endif()
+
+# ── Patch HighsOptions.h: register custom heuristic options ──
+file(READ "${LP_DATA_DIR}/HighsOptions.h" OPTIONS_CONTENT)
+
+string(FIND "${OPTIONS_CONTENT}" "mip_heuristic_run_fpr" _opts_found)
+if(_opts_found EQUAL -1)
+    # Member variables: insert after mip_heuristic_run_shifting
+    string(REPLACE
+      "bool mip_heuristic_run_shifting;\n"
+      "bool mip_heuristic_run_shifting;\n  bool mip_heuristic_run_fpr;\n  bool mip_heuristic_run_local_mip;\n  bool mip_heuristic_run_scylla_fpr;\n"
+      OPTIONS_CONTENT "${OPTIONS_CONTENT}")
+
+    # Constructor initializer list: insert after mip_heuristic_run_shifting(false),
+    string(REPLACE
+      "mip_heuristic_run_shifting(false),\n"
+      "mip_heuristic_run_shifting(false),\n        mip_heuristic_run_fpr(false),\n        mip_heuristic_run_local_mip(false),\n        mip_heuristic_run_scylla_fpr(false),\n"
+      OPTIONS_CONTENT "${OPTIONS_CONTENT}")
+
+    # Record registration: insert after the mip_heuristic_run_shifting record block
+    string(REPLACE
+      "record_bool = new OptionRecordBool(\"mip_heuristic_run_shifting\",\n                                       \"Use the Shifting heuristic\", advanced,\n                                       &mip_heuristic_run_shifting, false);\n    records.push_back(record_bool);"
+      "record_bool = new OptionRecordBool(\"mip_heuristic_run_shifting\",\n                                       \"Use the Shifting heuristic\", advanced,\n                                       &mip_heuristic_run_shifting, false);\n    records.push_back(record_bool);\n\n    record_bool = new OptionRecordBool(\"mip_heuristic_run_fpr\",\n                                       \"Use the FPR heuristic\", advanced,\n                                       &mip_heuristic_run_fpr, true);\n    records.push_back(record_bool);\n\n    record_bool = new OptionRecordBool(\"mip_heuristic_run_local_mip\",\n                                       \"Use the LocalMIP heuristic\", advanced,\n                                       &mip_heuristic_run_local_mip, true);\n    records.push_back(record_bool);\n\n    record_bool = new OptionRecordBool(\"mip_heuristic_run_scylla_fpr\",\n                                       \"Use the ScyllaFPR heuristic\", advanced,\n                                       &mip_heuristic_run_scylla_fpr, true);\n    records.push_back(record_bool);"
+      OPTIONS_CONTENT "${OPTIONS_CONTENT}")
+
+    file(WRITE "${LP_DATA_DIR}/HighsOptions.h" "${OPTIONS_CONTENT}")
+    message(STATUS "Applied option patches to HighsOptions.h")
+else()
+    message(STATUS "Option patches already applied to HighsOptions.h, skipping")
 endif()
 
 # ── Patch HighsMipSolver.cpp: insert heuristic call sites ──
@@ -23,13 +54,13 @@ if(_found EQUAL -1)
     # Patch A: after feasibilityJump block (pre-root-node, LP-free heuristics)
     string(REPLACE
       "    }\n    // End of pre-root-node heuristics"
-      "    }\n    fpr::run(*this);\n    local_mip::run(*this);\n\n    // End of pre-root-node heuristics"
+      "    }\n    if (options_mip_->mip_heuristic_run_fpr) fpr::run(*this);\n    if (options_mip_->mip_heuristic_run_local_mip) local_mip::run(*this);\n\n    // End of pre-root-node heuristics"
       CONTENT "${CONTENT}")
 
     # Patch B: after RINS/RENS block closing brace (B&B dive)
     string(REPLACE
       "          }\n\n          mipdata_->heuristics.flushStatistics();"
-      "          }\n          scylla_fpr::run(*this);\n\n          mipdata_->heuristics.flushStatistics();"
+      "          }\n          if (options_mip_->mip_heuristic_run_scylla_fpr) scylla_fpr::run(*this);\n\n          mipdata_->heuristics.flushStatistics();"
       CONTENT "${CONTENT}")
 
     file(WRITE "${MIP_DIR}/HighsMipSolver.cpp" "${CONTENT}")


### PR DESCRIPTION
## Summary
- Register three boolean HiGHS options (`mip_heuristic_run_fpr`, `mip_heuristic_run_local_mip`, `mip_heuristic_run_scylla_fpr`) following the existing `mip_heuristic_run_*` convention
- Gate heuristic call sites in `HighsMipSolver.cpp` with `if` guards on the new options
- All options default to `true` (heuristics enabled), matching existing HiGHS behavior

## Test plan
- [x] New test: set all three options to `false`, solve flugpl, verify correct objective
- [x] All 5 existing + new tests pass
- [x] Verified patched `HighsOptions.h` has correct member vars, constructor init, and record registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)