### PR TITLE
feat(portfolio): PortfolioWorker + Scylla arm (#44)

### DIFF
--- a/src/mode_dispatch.cpp
+++ b/src/mode_dispatch.cpp
@@ -72,8 +72,9 @@ bool run_presolve(HighsMipSolver &mipsolver, size_t budget) {
 
     if (options->mip_heuristic_portfolio) {
         portfolio::run_presolve(mipsolver, budget);
-        // Scylla runs independently in portfolio mode (not a portfolio arm yet).
-        if (options->mip_heuristic_run_scylla) {
+        // In opportunistic mode, Scylla is not yet a portfolio arm — run
+        // standalone.  Deterministic portfolio includes Scylla as an arm.
+        if (options->mip_heuristic_portfolio_opportunistic && options->mip_heuristic_run_scylla) {
             if (options->mip_heuristic_scylla_parallel) {
                 scylla::run_parallel(mipsolver, budget);
             } else {

--- a/src/portfolio.cpp
+++ b/src/portfolio.cpp
@@ -171,7 +171,9 @@ std::optional<PresolveSetup> build_presolve_setup(HighsMipSolver &mipsolver, siz
         s.enabled_arms.push_back(kArmLocalMIP);
         s.priors.push_back(kLocalMipAlpha);
     }
-    if (options->mip_heuristic_run_scylla) {
+    // Scylla is a deterministic portfolio arm only.  The opportunistic path
+    // uses run_presolve_arm() which has no kArmScylla handler (yet — #45).
+    if (options->mip_heuristic_run_scylla && !options->mip_heuristic_portfolio_opportunistic) {
         s.enabled_arms.push_back(kArmScylla);
         s.priors.push_back(kScyllaAlpha);
     }
@@ -298,14 +300,21 @@ public:
                 pump_ = std::make_unique<PumpWorker>(mipsolver_, setup_.csc, pool_, setup_.budget,
                                                      static_cast<uint32_t>(rng_()));
             }
+            auto t0 = std::chrono::steady_clock::now();
             epoch = pump_->run_epoch(epoch_budget);
+            auto t1 = std::chrono::steady_clock::now();
             finished_ = pump_->finished();
-            // Synthesize HeuristicResult for reward computation.
-            last_result_ = {};
-            last_result_.effort = epoch.effort;
+            // Accumulate HeuristicResult across Scylla epochs for reward computation.
+            // (last_result_ is reset in assign_arm(), not here.)
+            last_result_.effort += epoch.effort;
             if (epoch.found_improvement) {
                 last_result_.found_feasible = true;
                 last_result_.objective = pool_.snapshot().best_objective;
+            }
+            if (epoch.effort > 0) {
+                double wall_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+                log_arm_effort(mipsolver_.options_mip_->log_options, arm_type, epoch.effort,
+                               wall_ms);
             }
         } else {
             std::vector<double> restart;
@@ -350,6 +359,7 @@ public:
     void assign_arm(int bandit_arm_idx) {
         assigned_arm_ = bandit_arm_idx;
         finished_ = false;
+        last_result_ = {};
     }
 
     void set_pre_snapshot(SolutionPool::Snapshot snap) { pre_snap_ = snap; }

--- a/src/portfolio.cpp
+++ b/src/portfolio.cpp
@@ -1,10 +1,6 @@
 #include "portfolio.h"
 
-#include <atomic>
-#include <chrono>
-#include <random>
-#include <vector>
-
+#include "epoch_runner.h"
 #include "fpr_core.h"
 #include "fpr_strategies.h"
 #include "heuristic_common.h"
@@ -12,11 +8,16 @@
 #include "local_mip.h"
 #include "mip/HighsMipSolver.h"
 #include "mip/HighsMipSolverData.h"
-#include <optional>
-
 #include "parallel/HighsParallel.h"
+#include "pump_worker.h"
 #include "solution_pool.h"
 #include "thompson_sampler.h"
+
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <random>
+#include <vector>
 
 namespace portfolio {
 
@@ -25,22 +26,23 @@ namespace {
 // Arm indices for presolve portfolio (used as arm_type).
 // FPR arms 0-5 correspond to the paper's 6 LP-free configs.
 enum PresolveArm {
-  kArmFprDfsBadobjcl = 0,
-  kArmFprDfsLocks2,
-  kArmFprDiveLocks2,
-  kArmFprDfsrepLocks,
-  kArmFprDfsrepBadobjcl,
-  kArmFprDivepropRandom,
-  kArmFprRepairSearchLocks,
-  kArmLocalMIP,
-  kArmFJ,
+    kArmFprDfsBadobjcl = 0,
+    kArmFprDfsLocks2,
+    kArmFprDiveLocks2,
+    kArmFprDfsrepLocks,
+    kArmFprDfsrepBadobjcl,
+    kArmFprDivepropRandom,
+    kArmFprRepairSearchLocks,
+    kArmLocalMIP,
+    kArmFJ,
+    kArmScylla,
 };
 
 // Strategy configs for each FPR arm (matching fpr.cpp's kLpFreeConfigs)
 struct FprArmConfig {
-  int arm_id;
-  FprStrategyConfig strat;
-  FrameworkMode mode;
+    int arm_id;
+    FprStrategyConfig strat;
+    FrameworkMode mode;
 };
 constexpr FprArmConfig kFprArms[] = {
     {kArmFprDfsBadobjcl, kStratBadobjcl, FrameworkMode::kDfs},
@@ -56,69 +58,70 @@ constexpr int kNumFprArms = static_cast<int>(std::size(kFprArms));
 // Returns the FprArmConfig for the given arm_type, or nullptr if not FPR.
 // Arm IDs are contiguous 0..kNumFprArms-1, so direct index suffices.
 const FprArmConfig *find_fpr_arm(int arm_type) {
-  if (arm_type >= 0 && arm_type < kNumFprArms) return &kFprArms[arm_type];
-  return nullptr;
+    if (arm_type >= 0 && arm_type < kNumFprArms) {
+        return &kFprArms[arm_type];
+    }
+    return nullptr;
 }
 
 // Uniform priors (α=1, β=1): let the bandit learn from scratch.
 constexpr double kFjAlpha = 1.0;
 constexpr double kFprArmAlpha = 1.0;
 constexpr double kLocalMipAlpha = 1.0;
+constexpr double kScyllaAlpha = 1.0;
 
 bool objective_better(bool minimize, double lhs, double rhs) {
-  constexpr double kTol = 1e-9;
-  return minimize ? lhs < rhs - kTol : lhs > rhs + kTol;
+    constexpr double kTol = 1e-9;
+    return minimize ? lhs < rhs - kTol : lhs > rhs + kTol;
 }
 
 int compute_reward(SolutionPool::Snapshot before, SolutionPool::Snapshot after,
                    const HeuristicResult &result, bool minimize) {
-  if (!result.found_feasible) {
-    return 0;
-  }
-  if (!before.has_solution) {
-    // First feasible ever
-    return after.has_solution &&
-                   !objective_better(minimize, after.best_objective,
-                                     result.objective)
-               ? 2
-               : 1;
-  }
-  // Had solution before — check if we improved global best
-  bool improved =
-      after.has_solution &&
-      objective_better(minimize, after.best_objective, before.best_objective) &&
-      !objective_better(minimize, after.best_objective, result.objective);
-  return improved ? 3 : 1;
+    if (!result.found_feasible) {
+        return 0;
+    }
+    if (!before.has_solution) {
+        // First feasible ever
+        return after.has_solution &&
+                       !objective_better(minimize, after.best_objective, result.objective)
+                   ? 2
+                   : 1;
+    }
+    // Had solution before — check if we improved global best
+    bool improved = after.has_solution &&
+                    objective_better(minimize, after.best_objective, before.best_objective) &&
+                    !objective_better(minimize, after.best_objective, result.objective);
+    return improved ? 3 : 1;
 }
 
-constexpr const char* kArmNames[] = {
-    "FprDfsBadobjcl",      // kArmFprDfsBadobjcl
-    "FprDfsLocks2",        // kArmFprDfsLocks2
-    "FprDiveLocks2",       // kArmFprDiveLocks2
-    "FprDfsrepLocks",      // kArmFprDfsrepLocks
-    "FprDfsrepBadobjcl",   // kArmFprDfsrepBadobjcl
-    "FprDivepropRandom",   // kArmFprDivepropRandom
-    "FprRepairSearchLocks",// kArmFprRepairSearchLocks
-    "LocalMIP",            // kArmLocalMIP
-    "FJ",                  // kArmFJ
+constexpr const char *kArmNames[] = {
+    "FprDfsBadobjcl",        // kArmFprDfsBadobjcl
+    "FprDfsLocks2",          // kArmFprDfsLocks2
+    "FprDiveLocks2",         // kArmFprDiveLocks2
+    "FprDfsrepLocks",        // kArmFprDfsrepLocks
+    "FprDfsrepBadobjcl",     // kArmFprDfsrepBadobjcl
+    "FprDivepropRandom",     // kArmFprDivepropRandom
+    "FprRepairSearchLocks",  // kArmFprRepairSearchLocks
+    "LocalMIP",              // kArmLocalMIP
+    "FJ",                    // kArmFJ
+    "Scylla",                // kArmScylla
 };
-static_assert(std::size(kArmNames) == kArmFJ + 1,
-              "kArmNames must match PresolveArm enum");
+static_assert(std::size(kArmNames) == kArmScylla + 1, "kArmNames must match PresolveArm enum");
 
-const char* arm_name(int arm_type) {
-  if (arm_type >= 0 && arm_type < static_cast<int>(std::size(kArmNames)))
-    return kArmNames[arm_type];
-  return "Unknown";
+const char *arm_name(int arm_type) {
+    if (arm_type >= 0 && arm_type < static_cast<int>(std::size(kArmNames))) {
+        return kArmNames[arm_type];
+    }
+    return "Unknown";
 }
 
-void log_arm_effort(const HighsLogOptions &log_options, int arm_type,
-                    size_t effort, double wall_ms) {
-  double effort_per_ms =
-      wall_ms > 0.0 ? static_cast<double>(effort) / wall_ms : 0.0;
-  highsLogDev(log_options, HighsLogType::kVerbose,
-              "[Portfolio] arm=%s effort=%zu wall_ms=%.1f "
-              "effort_per_ms=%.0f\n",
-              arm_name(arm_type), effort, wall_ms, effort_per_ms);
+void log_arm_effort(const HighsLogOptions &log_options, int arm_type, size_t effort,
+                    double wall_ms) {
+    double effort_per_ms = wall_ms > 0.0 ? static_cast<double>(effort) / wall_ms : 0.0;
+    highsLogDev(log_options, HighsLogType::kVerbose,
+                "[Portfolio] arm=%s effort=%zu wall_ms=%.1f "
+                "effort_per_ms=%.0f\n",
+                arm_name(arm_type), effort, wall_ms, effort_per_ms);
 }
 
 // Pre-computed variable orders for FPR arms (avoids cliquePartition data race).
@@ -129,385 +132,426 @@ FprVarOrders precompute_fpr_var_orders(const HighsMipSolver &mipsolver);
 
 // Setup state shared between deterministic and opportunistic portfolio modes.
 struct PresolveSetup {
-  std::vector<int> enabled_arms;
-  std::vector<double> priors;
-  CscMatrix csc;
-  FprVarOrders fpr_var_orders;
-  std::vector<double> incumbent_snapshot;
-  size_t budget;
-  size_t stale_budget;
-  bool minimize;
+    std::vector<int> enabled_arms;
+    std::vector<double> priors;
+    CscMatrix csc;
+    FprVarOrders fpr_var_orders;
+    std::vector<double> incumbent_snapshot;
+    size_t budget;
+    size_t stale_budget;
+    bool minimize;
 };
 
-std::optional<PresolveSetup> build_presolve_setup(
-    HighsMipSolver &mipsolver, size_t max_effort) {
-  const auto *model = mipsolver.model_;
-  auto *mipdata = mipsolver.mipdata_.get();
-  const auto *options = mipsolver.options_mip_;
-  const HighsInt ncol = model->num_col_;
-  const HighsInt nrow = model->num_row_;
-  if (ncol == 0 || nrow == 0) return std::nullopt;
-
-  PresolveSetup s;
-  s.minimize = (model->sense_ == ObjSense::kMinimize);
-  s.budget = max_effort;
-  s.stale_budget = max_effort >> 2;
-
-  if (options->mip_heuristic_run_feasibility_jump) {
-    s.enabled_arms.push_back(kArmFJ);
-    s.priors.push_back(kFjAlpha);
-  }
-  if (options->mip_heuristic_run_fpr) {
-    for (int i = 0; i < kNumFprArms; ++i) {
-      s.enabled_arms.push_back(kFprArms[i].arm_id);
-      s.priors.push_back(kFprArmAlpha);
+std::optional<PresolveSetup> build_presolve_setup(HighsMipSolver &mipsolver, size_t max_effort) {
+    const auto *model = mipsolver.model_;
+    auto *mipdata = mipsolver.mipdata_.get();
+    const auto *options = mipsolver.options_mip_;
+    const HighsInt ncol = model->num_col_;
+    const HighsInt nrow = model->num_row_;
+    if (ncol == 0 || nrow == 0) {
+        return std::nullopt;
     }
-  }
-  if (options->mip_heuristic_run_local_mip) {
-    s.enabled_arms.push_back(kArmLocalMIP);
-    s.priors.push_back(kLocalMipAlpha);
-  }
-  if (s.enabled_arms.empty()) return std::nullopt;
 
-  s.csc = build_csc(ncol, nrow, mipdata->ARstart_, mipdata->ARindex_,
-                     mipdata->ARvalue_);
+    PresolveSetup s;
+    s.minimize = (model->sense_ == ObjSense::kMinimize);
+    s.budget = max_effort;
+    s.stale_budget = max_effort >> 2;
 
-  if (options->mip_heuristic_run_fpr) {
-    s.fpr_var_orders = precompute_fpr_var_orders(mipsolver);
-  }
+    if (options->mip_heuristic_run_feasibility_jump) {
+        s.enabled_arms.push_back(kArmFJ);
+        s.priors.push_back(kFjAlpha);
+    }
+    if (options->mip_heuristic_run_fpr) {
+        for (int i = 0; i < kNumFprArms; ++i) {
+            s.enabled_arms.push_back(kFprArms[i].arm_id);
+            s.priors.push_back(kFprArmAlpha);
+        }
+    }
+    if (options->mip_heuristic_run_local_mip) {
+        s.enabled_arms.push_back(kArmLocalMIP);
+        s.priors.push_back(kLocalMipAlpha);
+    }
+    if (options->mip_heuristic_run_scylla) {
+        s.enabled_arms.push_back(kArmScylla);
+        s.priors.push_back(kScyllaAlpha);
+    }
+    if (s.enabled_arms.empty()) {
+        return std::nullopt;
+    }
 
-  s.incumbent_snapshot = mipdata->incumbent;
-  return s;
+    s.csc = build_csc(ncol, nrow, mipdata->ARstart_, mipdata->ARindex_, mipdata->ARvalue_);
+
+    if (options->mip_heuristic_run_fpr) {
+        s.fpr_var_orders = precompute_fpr_var_orders(mipsolver);
+    }
+
+    s.incumbent_snapshot = mipdata->incumbent;
+    return s;
 }
 
 FprVarOrders precompute_fpr_var_orders(const HighsMipSolver &mipsolver) {
-  FprVarOrders orders(kNumFprArms);
-  for (int i = 0; i < kNumFprArms; ++i) {
-    std::mt19937 rng(42 + static_cast<uint32_t>(i));
-    orders[i] = compute_var_order(mipsolver, kFprArms[i].strat.var_strategy,
-                                  rng, nullptr);
-  }
-  return orders;
+    FprVarOrders orders(kNumFprArms);
+    for (int i = 0; i < kNumFprArms; ++i) {
+        std::mt19937 rng(42 + static_cast<uint32_t>(i));
+        orders[i] = compute_var_order(mipsolver, kFprArms[i].strat.var_strategy, rng, nullptr);
+    }
+    return orders;
 }
 
-HeuristicResult run_presolve_arm(HighsMipSolver &mipsolver, int arm_type,
-                                 std::mt19937 &rng, int attempt_idx,
-                                 const double *restart_sol,
-                                 const CscMatrix &csc,
-                                 const std::vector<double> &incumbent_snapshot,
-                                 size_t max_effort,
+HeuristicResult run_presolve_arm(HighsMipSolver &mipsolver, int arm_type, std::mt19937 &rng,
+                                 int attempt_idx, const double *restart_sol, const CscMatrix &csc,
+                                 const std::vector<double> &incumbent_snapshot, size_t max_effort,
                                  const FprVarOrders &fpr_var_orders) {
-  if (mipsolver.mipdata_->terminatorTerminated()) {
-    return {};
-  }
-  if (mipsolver.timer_.read() >= mipsolver.options_mip_->time_limit) {
-    return {};
-  }
-  // Check if this is an FPR config arm
-  const FprArmConfig *fpr_arm = find_fpr_arm(arm_type);
-  if (fpr_arm) {
-    // Find the index into kFprArms for this arm
-    int fpr_idx = static_cast<int>(fpr_arm - kFprArms);
-
-    FprConfig cfg{};
-    cfg.max_effort = max_effort;
-    cfg.hint =
-        incumbent_snapshot.empty() ? nullptr : incumbent_snapshot.data();
-    cfg.scores = nullptr;
-    cfg.cont_fallback = nullptr;
-    cfg.csc = &csc;
-    cfg.mode = fpr_arm->mode;
-    cfg.strategy = &fpr_arm->strat;
-    cfg.lp_ref = nullptr;
-    // Use pre-computed var order to avoid cliquePartition data race
-    cfg.precomputed_var_order = fpr_var_orders[fpr_idx].data();
-    cfg.precomputed_var_order_size =
-        static_cast<HighsInt>(fpr_var_orders[fpr_idx].size());
-    return fpr_attempt(mipsolver, cfg, rng, attempt_idx, restart_sol);
-  }
-
-  switch (arm_type) {
-  case kArmLocalMIP: {
-    const double *init = restart_sol;
-    if (!init && !incumbent_snapshot.empty()) {
-      init = incumbent_snapshot.data();
+    if (mipsolver.mipdata_->terminatorTerminated()) {
+        return {};
     }
-    uint32_t seed = static_cast<uint32_t>(rng());
-    return local_mip::worker(mipsolver, csc, seed, init, max_effort);
-  }
-  case kArmFJ: {
-    auto *mipdata = mipsolver.mipdata_.get();
-    const HighsInt ncol = mipsolver.model_->num_col_;
-    HeuristicResult result;
-    std::vector<double> captured_sol;
-    double captured_obj = 0.0;
+    if (mipsolver.timer_.read() >= mipsolver.options_mip_->time_limit) {
+        return {};
+    }
+    // Check if this is an FPR config arm
+    const FprArmConfig *fpr_arm = find_fpr_arm(arm_type);
+    if (fpr_arm) {
+        // Find the index into kFprArms for this arm
+        int fpr_idx = static_cast<int>(fpr_arm - kFprArms);
 
-    // Prefer pool restart over static incumbent snapshot.
-    // restart_sol is a raw pointer from the pool, so we must copy into a
-    // vector to satisfy the FJ signature (const vector<double>*).
-    const std::vector<double> *hint = nullptr;
-    std::vector<double> restart_vec;
-    if (restart_sol) {
-      restart_vec.assign(restart_sol, restart_sol + ncol);
-      hint = &restart_vec;
-    } else if (!incumbent_snapshot.empty()) {
-      hint = &incumbent_snapshot;
+        FprConfig cfg{};
+        cfg.max_effort = max_effort;
+        cfg.hint = incumbent_snapshot.empty() ? nullptr : incumbent_snapshot.data();
+        cfg.scores = nullptr;
+        cfg.cont_fallback = nullptr;
+        cfg.csc = &csc;
+        cfg.mode = fpr_arm->mode;
+        cfg.strategy = &fpr_arm->strat;
+        cfg.lp_ref = nullptr;
+        // Use pre-computed var order to avoid cliquePartition data race
+        cfg.precomputed_var_order = fpr_var_orders[fpr_idx].data();
+        cfg.precomputed_var_order_size = static_cast<HighsInt>(fpr_var_orders[fpr_idx].size());
+        return fpr_attempt(mipsolver, cfg, rng, attempt_idx, restart_sol);
     }
 
-    size_t fj_effort = 0;
-    mipdata->feasibilityJumpCapture(captured_sol, captured_obj, fj_effort,
-                                    max_effort, hint);
-    if (!captured_sol.empty()) {
-      result.found_feasible = true;
-      result.solution = std::move(captured_sol);
-      result.objective = captured_obj;
+    switch (arm_type) {
+        case kArmLocalMIP: {
+            const double *init = restart_sol;
+            if (!init && !incumbent_snapshot.empty()) {
+                init = incumbent_snapshot.data();
+            }
+            uint32_t seed = static_cast<uint32_t>(rng());
+            return local_mip::worker(mipsolver, csc, seed, init, max_effort);
+        }
+        case kArmFJ: {
+            auto *mipdata = mipsolver.mipdata_.get();
+            const HighsInt ncol = mipsolver.model_->num_col_;
+            HeuristicResult result;
+            std::vector<double> captured_sol;
+            double captured_obj = 0.0;
+
+            // Prefer pool restart over static incumbent snapshot.
+            // restart_sol is a raw pointer from the pool, so we must copy into a
+            // vector to satisfy the FJ signature (const vector<double>*).
+            const std::vector<double> *hint = nullptr;
+            std::vector<double> restart_vec;
+            if (restart_sol) {
+                restart_vec.assign(restart_sol, restart_sol + ncol);
+                hint = &restart_vec;
+            } else if (!incumbent_snapshot.empty()) {
+                hint = &incumbent_snapshot;
+            }
+
+            size_t fj_effort = 0;
+            mipdata->feasibilityJumpCapture(captured_sol, captured_obj, fj_effort, max_effort,
+                                            hint);
+            if (!captured_sol.empty()) {
+                result.found_feasible = true;
+                result.solution = std::move(captured_sol);
+                result.objective = captured_obj;
+            }
+            result.effort = fj_effort;
+            return result;
+        }
+        default:
+            return {};
     }
-    result.effort = fj_effort;
-    return result;
-  }
-  default:
-    return {};
-  }
 }
 
-void run_presolve_opportunistic(HighsMipSolver &mipsolver,
-                                const PresolveSetup &setup) {
-  auto *mipdata = mipsolver.mipdata_.get();
-  const HighsLogOptions &log_options =
-      mipsolver.options_mip_->log_options;
-  const int N = highs::parallel::num_threads();
-  const int num_arms = static_cast<int>(setup.enabled_arms.size());
+// ── PortfolioWorker: EpochWorker wrapper for bandit-selected arms ──
+//
+// Each worker runs whichever arm the bandit assigns.  Non-Scylla arms
+// are stateless (one invocation per epoch, then finished=true triggers
+// reassignment).  Scylla arms delegate to a persistent PumpWorker that
+// preserves PDLP warm-start state across epochs.
+class PortfolioWorker {
+public:
+    PortfolioWorker(HighsMipSolver &mipsolver, const PresolveSetup &setup, SolutionPool &pool,
+                    uint32_t seed)
+        : mipsolver_(mipsolver), setup_(setup), pool_(pool), rng_(seed) {}
 
-  ThompsonSampler bandit(num_arms, setup.priors.data(), true);
-  SolutionPool pool(kPoolCapacity, setup.minimize);
-  seed_pool(pool, mipsolver);
+    EpochResult run_epoch(size_t epoch_budget) {
+        if (finished_) {
+            return {};
+        }
 
-  const auto &enabled_arms = setup.enabled_arms;
-  const auto &incumbent_snapshot = setup.incumbent_snapshot;
-  const auto &csc = setup.csc;
-  const auto &fpr_var_orders = setup.fpr_var_orders;
-  const bool minimize = setup.minimize;
-  const size_t budget = setup.budget;
-  const size_t stale_budget = setup.stale_budget;
+        const int arm_type = setup_.enabled_arms[assigned_arm_];
+        EpochResult epoch{};
 
-  const double time_limit = mipsolver.options_mip_->time_limit;
-
-  std::atomic<size_t> total_effort{0};
-  std::atomic<size_t> effort_since_improvement{0};
-  std::atomic<bool> stop{false};
-
-  uint32_t base_seed =
-      static_cast<uint32_t>(mipdata->numImprovingSols + kBaseSeedOffset);
-
-  highs::parallel::for_each(
-      0, static_cast<HighsInt>(N),
-      [&](HighsInt lo, HighsInt hi) {
-        for (HighsInt w = lo; w < hi; ++w) {
-          std::mt19937 rng(base_seed + static_cast<uint32_t>(w) * kSeedStride);
-          int attempt_counter = 0;
-
-          while (!stop.load(std::memory_order_relaxed)) {
-            // Worker 0 periodically checks termination (not thread-safe
-            // to call from multiple workers)
-            if (w == 0 && attempt_counter % 8 == 0) {
-              if (mipdata->terminatorTerminated() ||
-                  mipsolver.timer_.read() >= time_limit) {
-                stop.store(true, std::memory_order_relaxed);
-              }
+        if (arm_type == kArmScylla) {
+            if (!pump_ || pump_->finished()) {
+                pump_ = std::make_unique<PumpWorker>(mipsolver_, setup_.csc, pool_, setup_.budget,
+                                                     static_cast<uint32_t>(rng_()));
             }
-            if (stop.load(std::memory_order_relaxed)) {
-              break;
+            epoch = pump_->run_epoch(epoch_budget);
+            finished_ = pump_->finished();
+            // Synthesize HeuristicResult for reward computation.
+            last_result_ = {};
+            last_result_.effort = epoch.effort;
+            if (epoch.found_improvement) {
+                last_result_.found_feasible = true;
+                last_result_.objective = pool_.snapshot().best_objective;
             }
-
-            int arm = bandit.select_effort_aware(rng);
-            auto before = pool.snapshot();
-
+        } else {
             std::vector<double> restart;
-            pool.get_restart(rng, restart);
-            const double *restart_ptr =
-                restart.empty() ? nullptr : restart.data();
+            pool_.get_restart(rng_, restart);
+            const double *restart_ptr = restart.empty() ? nullptr : restart.data();
 
-            size_t remaining =
-                budget -
-                std::min(budget, total_effort.load(std::memory_order_relaxed));
             auto t0 = std::chrono::steady_clock::now();
-            auto result = run_presolve_arm(mipsolver, enabled_arms[arm], rng,
-                                           attempt_counter++, restart_ptr, csc,
-                                           incumbent_snapshot, remaining,
-                                           fpr_var_orders);
+            last_result_ = run_presolve_arm(mipsolver_, arm_type, rng_, attempt_counter_++,
+                                            restart_ptr, setup_.csc, setup_.incumbent_snapshot,
+                                            epoch_budget, setup_.fpr_var_orders);
             auto t1 = std::chrono::steady_clock::now();
 
-            if (result.found_feasible) {
-              pool.try_add(result.objective, result.solution);
+            epoch.effort = last_result_.effort;
+            if (last_result_.found_feasible) {
+                pool_.try_add(last_result_.objective, last_result_.solution);
+                epoch.found_improvement = true;
             }
 
-            auto after = pool.snapshot();
-            int reward = compute_reward(before, after, result, minimize);
-            bandit.update(arm, reward);
-            bandit.record_effort(arm, result.effort);
-
-            if (result.effort > 0) {
-              double wall_ms =
-                  std::chrono::duration<double, std::milli>(t1 - t0).count();
-              log_arm_effort(log_options, enabled_arms[arm], result.effort,
-                             wall_ms);
+            if (last_result_.effort > 0) {
+                double wall_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+                log_arm_effort(mipsolver_.options_mip_->log_options, arm_type, last_result_.effort,
+                               wall_ms);
             }
 
-            if (reward >= 2) {
-              effort_since_improvement.store(0, std::memory_order_relaxed);
-            } else {
-              effort_since_improvement.fetch_add(result.effort,
-                                                 std::memory_order_relaxed);
-            }
-
-            if (effort_since_improvement.load(std::memory_order_relaxed) >=
-                stale_budget) {
-              stop.store(true, std::memory_order_relaxed);
-            }
-
-            size_t new_total =
-                total_effort.fetch_add(result.effort) + result.effort;
-            if (new_total >= budget) {
-              stop.store(true, std::memory_order_relaxed);
-            }
-          }
+            // Non-Scylla arms: mark finished so restart callback reassigns.
+            finished_ = true;
         }
-      },
-      1);
 
-  mipdata->heuristic_effort_used +=
-      total_effort.load(std::memory_order_relaxed);
-
-  // Flush pool solutions to HiGHS (sequential, use generic H tag since
-  // pool mixes arms)
-  for (auto &entry : pool.sorted_entries()) {
-    mipdata->trySolution(entry.solution, kSolutionSourceHeuristic);
-  }
-}
-
-} // namespace
-
-void run_presolve(HighsMipSolver &mipsolver, size_t max_effort) {
-  auto setup_opt = build_presolve_setup(mipsolver, max_effort);
-  if (!setup_opt) return;
-  auto &setup = *setup_opt;
-
-  // Dispatch to opportunistic mode if requested
-  if (mipsolver.options_mip_->mip_heuristic_portfolio_opportunistic) {
-    run_presolve_opportunistic(mipsolver, setup);
-    return;
-  }
-
-  auto *mipdata = mipsolver.mipdata_.get();
-  const int N = highs::parallel::num_threads();
-
-  const auto &enabled_arms = setup.enabled_arms;
-  const auto &incumbent_snapshot = setup.incumbent_snapshot;
-  const auto &csc = setup.csc;
-  const auto &fpr_var_orders = setup.fpr_var_orders;
-  const bool minimize = setup.minimize;
-
-  ThompsonSampler bandit(static_cast<int>(enabled_arms.size()),
-                         setup.priors.data(), false);
-  SolutionPool pool(kPoolCapacity, minimize);
-  seed_pool(pool, mipsolver);
-
-  size_t total_effort = 0;
-  size_t effort_since_improvement = 0;
-
-  const double time_limit = mipsolver.options_mip_->time_limit;
-
-  uint32_t base_seed =
-      static_cast<uint32_t>(mipdata->numImprovingSols + kBaseSeedOffset);
-  std::vector<std::mt19937> rngs(N);
-  for (int w = 0; w < N; ++w) {
-    rngs[w].seed(base_seed + w * kSeedStride);
-  }
-  std::vector<int> attempt_counters(N, 0);
-
-  const HighsLogOptions &log_options = mipsolver.options_mip_->log_options;
-
-  // Pre-allocate per-worker vectors outside epoch loop
-  std::vector<int> arms(N);
-  std::vector<HeuristicResult> results(N);
-  std::vector<double> wall_ms_vec(N);
-  std::vector<std::vector<double>> restarts(N);
-
-  for (int epoch = 0; total_effort < setup.budget; ++epoch) {
-    if (mipdata->terminatorTerminated() ||
-        mipsolver.timer_.read() >= time_limit) {
-      break;
-    }
-    if (effort_since_improvement > setup.stale_budget) {
-      break;
+        return epoch;
     }
 
-    // Pre-epoch: snapshot + get restarts (sequential, deterministic)
-    auto pool_snap = pool.snapshot();
-    for (int w = 0; w < N; ++w) {
-      restarts[w].clear();
-      pool.get_restart(rngs[w], restarts[w]);
+    bool finished() const { return finished_; }
+
+    void reset_staleness() {
+        if (pump_) {
+            pump_->reset_staleness();
+        }
     }
 
-    // Select arms deterministically (sequential, uses effort-aware sampling)
-    for (int w = 0; w < N; ++w) {
-      arms[w] = bandit.select_effort_aware(rngs[w]);
+    // --- Portfolio-specific interface (used by restart callback) ---
+
+    void assign_arm(int bandit_arm_idx) {
+        assigned_arm_ = bandit_arm_idx;
+        finished_ = false;
     }
+
+    void set_pre_snapshot(SolutionPool::Snapshot snap) { pre_snap_ = snap; }
+
+    int assigned_arm() const { return assigned_arm_; }
+    const HeuristicResult &last_result() const { return last_result_; }
+    SolutionPool::Snapshot pre_snapshot() const { return pre_snap_; }
+
+private:
+    HighsMipSolver &mipsolver_;
+    const PresolveSetup &setup_;
+    SolutionPool &pool_;
+    std::mt19937 rng_;
+
+    int assigned_arm_ = -1;
+    int attempt_counter_ = 0;
+    bool finished_ = true;  // starts finished → restart fires on epoch 0
+
+    HeuristicResult last_result_{};
+    SolutionPool::Snapshot pre_snap_{};
+
+    std::unique_ptr<PumpWorker> pump_;  // lazy-init, persists across reassignments
+};
+
+static_assert(EpochWorker<PortfolioWorker>, "PortfolioWorker must satisfy EpochWorker concept");
+
+void run_presolve_opportunistic(HighsMipSolver &mipsolver, const PresolveSetup &setup) {
+    auto *mipdata = mipsolver.mipdata_.get();
+    const HighsLogOptions &log_options = mipsolver.options_mip_->log_options;
+    const int N = highs::parallel::num_threads();
+    const int num_arms = static_cast<int>(setup.enabled_arms.size());
+
+    ThompsonSampler bandit(num_arms, setup.priors.data(), true);
+    SolutionPool pool(kPoolCapacity, setup.minimize);
+    seed_pool(pool, mipsolver);
+
+    const auto &enabled_arms = setup.enabled_arms;
+    const auto &incumbent_snapshot = setup.incumbent_snapshot;
+    const auto &csc = setup.csc;
+    const auto &fpr_var_orders = setup.fpr_var_orders;
+    const bool minimize = setup.minimize;
+    const size_t budget = setup.budget;
+    const size_t stale_budget = setup.stale_budget;
+
+    const double time_limit = mipsolver.options_mip_->time_limit;
+
+    std::atomic<size_t> total_effort{0};
+    std::atomic<size_t> effort_since_improvement{0};
+    std::atomic<bool> stop{false};
+
+    uint32_t base_seed = static_cast<uint32_t>(mipdata->numImprovingSols + kBaseSeedOffset);
 
     highs::parallel::for_each(
         0, static_cast<HighsInt>(N),
         [&](HighsInt lo, HighsInt hi) {
-          for (HighsInt w = lo; w < hi; ++w) {
-            const double *restart_ptr =
-                restarts[w].empty() ? nullptr : restarts[w].data();
-            size_t remaining = setup.budget - std::min(setup.budget, total_effort);
-            auto t0 = std::chrono::steady_clock::now();
-            results[w] = run_presolve_arm(
-                mipsolver, enabled_arms[arms[w]], rngs[w], attempt_counters[w],
-                restart_ptr, csc, incumbent_snapshot, remaining,
-                fpr_var_orders);
-            auto t1 = std::chrono::steady_clock::now();
-            wall_ms_vec[w] =
-                std::chrono::duration<double, std::milli>(t1 - t0).count();
-          }
+            for (HighsInt w = lo; w < hi; ++w) {
+                std::mt19937 rng(base_seed + static_cast<uint32_t>(w) * kSeedStride);
+                int attempt_counter = 0;
+
+                while (!stop.load(std::memory_order_relaxed)) {
+                    // Worker 0 periodically checks termination (not thread-safe
+                    // to call from multiple workers)
+                    if (w == 0 && attempt_counter % 8 == 0) {
+                        if (mipdata->terminatorTerminated() ||
+                            mipsolver.timer_.read() >= time_limit) {
+                            stop.store(true, std::memory_order_relaxed);
+                        }
+                    }
+                    if (stop.load(std::memory_order_relaxed)) {
+                        break;
+                    }
+
+                    int arm = bandit.select_effort_aware(rng);
+                    auto before = pool.snapshot();
+
+                    std::vector<double> restart;
+                    pool.get_restart(rng, restart);
+                    const double *restart_ptr = restart.empty() ? nullptr : restart.data();
+
+                    size_t remaining =
+                        budget - std::min(budget, total_effort.load(std::memory_order_relaxed));
+                    auto t0 = std::chrono::steady_clock::now();
+                    auto result = run_presolve_arm(mipsolver, enabled_arms[arm], rng,
+                                                   attempt_counter++, restart_ptr, csc,
+                                                   incumbent_snapshot, remaining, fpr_var_orders);
+                    auto t1 = std::chrono::steady_clock::now();
+
+                    if (result.found_feasible) {
+                        pool.try_add(result.objective, result.solution);
+                    }
+
+                    auto after = pool.snapshot();
+                    int reward = compute_reward(before, after, result, minimize);
+                    bandit.update(arm, reward);
+                    bandit.record_effort(arm, result.effort);
+
+                    if (result.effort > 0) {
+                        double wall_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+                        log_arm_effort(log_options, enabled_arms[arm], result.effort, wall_ms);
+                    }
+
+                    if (reward >= 2) {
+                        effort_since_improvement.store(0, std::memory_order_relaxed);
+                    } else {
+                        effort_since_improvement.fetch_add(result.effort,
+                                                           std::memory_order_relaxed);
+                    }
+
+                    if (effort_since_improvement.load(std::memory_order_relaxed) >= stale_budget) {
+                        stop.store(true, std::memory_order_relaxed);
+                    }
+
+                    size_t new_total = total_effort.fetch_add(result.effort) + result.effort;
+                    if (new_total >= budget) {
+                        stop.store(true, std::memory_order_relaxed);
+                    }
+                }
+            }
         },
         1);
 
-    // Post-epoch: merge in deterministic worker order
-    for (int w = 0; w < N; ++w) {
-      if (results[w].found_feasible) {
-        pool.try_add(results[w].objective, results[w].solution);
-      }
+    mipdata->heuristic_effort_used += total_effort.load(std::memory_order_relaxed);
 
-      auto after_snap = pool.snapshot();
-      int reward = compute_reward(pool_snap, after_snap, results[w], minimize);
-      bandit.update(arms[w], reward);
-      bandit.record_effort(arms[w], results[w].effort);
-      total_effort += results[w].effort;
-      attempt_counters[w]++;
-
-      if (results[w].effort > 0) {
-        log_arm_effort(log_options, enabled_arms[arms[w]],
-                       results[w].effort, wall_ms_vec[w]);
-      }
-
-      if (reward >= 2) {
-        effort_since_improvement = 0;
-      } else {
-        effort_since_improvement += results[w].effort;
-      }
-
-      // Update snapshot for next worker's reward computation
-      pool_snap = after_snap;
+    // Flush pool solutions to HiGHS (sequential, use generic H tag since
+    // pool mixes arms)
+    for (auto &entry : pool.sorted_entries()) {
+        mipdata->trySolution(entry.solution, kSolutionSourceHeuristic);
     }
-  }
-
-  mipdata->heuristic_effort_used += total_effort;
-
-  // Flush pool solutions to HiGHS (best first)
-  for (auto &entry : pool.sorted_entries()) {
-    mipdata->trySolution(entry.solution, kSolutionSourceHeuristic);
-  }
 }
 
-} // namespace portfolio
+}  // namespace
+
+void run_presolve(HighsMipSolver &mipsolver, size_t max_effort) {
+    auto setup_opt = build_presolve_setup(mipsolver, max_effort);
+    if (!setup_opt) {
+        return;
+    }
+    auto &setup = *setup_opt;
+
+    // Dispatch to opportunistic mode if requested
+    if (mipsolver.options_mip_->mip_heuristic_portfolio_opportunistic) {
+        run_presolve_opportunistic(mipsolver, setup);
+        return;
+    }
+
+    auto *mipdata = mipsolver.mipdata_.get();
+    const int N = highs::parallel::num_threads();
+    const int num_arms = static_cast<int>(setup.enabled_arms.size());
+    const bool minimize = setup.minimize;
+    const HighsLogOptions &log_options = mipsolver.options_mip_->log_options;
+
+    ThompsonSampler bandit(num_arms, setup.priors.data(), /*use_mutex=*/false);
+    SolutionPool pool(kPoolCapacity, minimize);
+    seed_pool(pool, mipsolver);
+
+    uint32_t base_seed = static_cast<uint32_t>(mipdata->numImprovingSols + kBaseSeedOffset);
+
+    // Separate RNGs for bandit selection in the restart callback (sequential).
+    std::vector<std::mt19937> bandit_rngs(N);
+    for (int w = 0; w < N; ++w) {
+        bandit_rngs[w].seed(base_seed + static_cast<uint32_t>(w) * kSeedStride + 1);
+    }
+
+    // Workers start with finished_=true so the first restart callback assigns
+    // their initial arms.
+    std::vector<std::unique_ptr<PortfolioWorker>> workers;
+    workers.reserve(N);
+    for (int w = 0; w < N; ++w) {
+        uint32_t seed = base_seed + static_cast<uint32_t>(w) * kSeedStride;
+        workers.push_back(std::make_unique<PortfolioWorker>(mipsolver, setup, pool, seed));
+    }
+
+    constexpr int kEpochsPerWorker = 20;
+    const size_t epoch_budget =
+        std::max<size_t>(setup.budget / (static_cast<size_t>(N) * kEpochsPerWorker), 1);
+
+    size_t total_effort = run_epoch_loop(
+        mipsolver, workers, setup.budget, epoch_budget,
+        [&](int w) {
+            auto &worker = *workers[w];
+            // Update bandit from previous epoch (skip initial assignment).
+            if (worker.assigned_arm() >= 0) {
+                auto after_snap = pool.snapshot();
+                int reward = compute_reward(worker.pre_snapshot(), after_snap, worker.last_result(),
+                                            minimize);
+                bandit.update(worker.assigned_arm(), reward);
+                bandit.record_effort(worker.assigned_arm(), worker.last_result().effort);
+            }
+            // Snapshot pool before next epoch (sequential, deterministic).
+            worker.set_pre_snapshot(pool.snapshot());
+            // Select next arm.
+            int arm = bandit.select_effort_aware(bandit_rngs[w]);
+            worker.assign_arm(arm);
+        },
+        setup.stale_budget);
+
+    mipdata->heuristic_effort_used += total_effort;
+
+    // Flush pool solutions to HiGHS (best first).
+    for (auto &entry : pool.sorted_entries()) {
+        mipdata->trySolution(entry.solution, kSolutionSourceHeuristic);
+    }
+}
+
+}  // namespace portfolio

--- a/src/portfolio.h
+++ b/src/portfolio.h
@@ -6,7 +6,7 @@ class HighsMipSolver;
 
 namespace portfolio {
 
-// Run presolve-based portfolio (pre-root): FPR, LocalMIP, FJ arms.
+// Run presolve-based portfolio (pre-root): FPR, LocalMIP, FJ, Scylla arms.
 void run_presolve(HighsMipSolver &mipsolver, size_t max_effort);
 
-} // namespace portfolio
+}  // namespace portfolio

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -471,6 +471,7 @@ TEST_CASE("Portfolio: all presolve arms disabled still solves", "[portfolio][edg
     highs.setOptionValue("mip_heuristic_run_fpr", false);
     highs.setOptionValue("mip_heuristic_run_local_mip", false);
     highs.setOptionValue("mip_heuristic_run_feasibility_jump", false);
+    highs.setOptionValue("mip_heuristic_run_scylla", false);
     REQUIRE(highs.readModel(kInstancesDir + "/flugpl.mps") == HighsStatus::kOk);
     REQUIRE(highs.run() == HighsStatus::kOk);
     double obj;
@@ -487,6 +488,7 @@ TEST_CASE("Portfolio opportunistic: all arms disabled still solves",
     highs.setOptionValue("mip_heuristic_run_fpr", false);
     highs.setOptionValue("mip_heuristic_run_local_mip", false);
     highs.setOptionValue("mip_heuristic_run_feasibility_jump", false);
+    highs.setOptionValue("mip_heuristic_run_scylla", false);
     REQUIRE(highs.readModel(kInstancesDir + "/flugpl.mps") == HighsStatus::kOk);
     REQUIRE(highs.run() == HighsStatus::kOk);
     double obj;
@@ -811,7 +813,7 @@ TEST_CASE("Sequential orchestrator: egout all arms", "[heuristic][sequential]") 
     REQUIRE(obj == Catch::Approx(568.1007).epsilon(1e-4));
 }
 
-TEST_CASE("Portfolio + Scylla: flugpl bandit then Scylla", "[portfolio][scylla]") {
+TEST_CASE("Portfolio: Scylla arm finds solution on flugpl", "[portfolio][scylla]") {
     Highs highs;
     highs.setOptionValue("output_flag", false);
     highs.setOptionValue("mip_heuristic_run_scylla", true);
@@ -823,7 +825,7 @@ TEST_CASE("Portfolio + Scylla: flugpl bandit then Scylla", "[portfolio][scylla]"
     REQUIRE(obj == Catch::Approx(1201500.0).epsilon(1e-6));
 }
 
-TEST_CASE("Portfolio + Scylla: egout independent budgets", "[portfolio][scylla]") {
+TEST_CASE("Portfolio: Scylla arm finds solution on egout", "[portfolio][scylla]") {
     Highs highs;
     highs.setOptionValue("output_flag", false);
     highs.setOptionValue("mip_heuristic_run_scylla", true);
@@ -833,6 +835,37 @@ TEST_CASE("Portfolio + Scylla: egout independent budgets", "[portfolio][scylla]"
     double obj;
     highs.getInfoValue("objective_function_value", obj);
     REQUIRE(obj == Catch::Approx(568.1007).epsilon(1e-4));
+}
+
+TEST_CASE("Portfolio: Scylla-only single arm", "[portfolio][scylla][single-arm]") {
+    Highs highs;
+    highs.setOptionValue("output_flag", false);
+    highs.setOptionValue("mip_heuristic_portfolio", true);
+    highs.setOptionValue("mip_heuristic_run_fpr", false);
+    highs.setOptionValue("mip_heuristic_run_local_mip", false);
+    highs.setOptionValue("mip_heuristic_run_feasibility_jump", false);
+    highs.setOptionValue("mip_heuristic_run_scylla", true);
+    REQUIRE(highs.readModel(kInstancesDir + "/flugpl.mps") == HighsStatus::kOk);
+    REQUIRE(highs.run() == HighsStatus::kOk);
+    double obj;
+    highs.getInfoValue("objective_function_value", obj);
+    REQUIRE(obj == Catch::Approx(1201500.0).epsilon(1e-6));
+}
+
+TEST_CASE("Portfolio deterministic: Scylla arm same result", "[portfolio][scylla][determinism]") {
+    auto run_once = [](double& obj) {
+        Highs highs;
+        highs.setOptionValue("output_flag", false);
+        highs.setOptionValue("mip_heuristic_portfolio", true);
+        highs.setOptionValue("mip_heuristic_run_scylla", true);
+        REQUIRE(highs.readModel(kInstancesDir + "/flugpl.mps") == HighsStatus::kOk);
+        REQUIRE(highs.run() == HighsStatus::kOk);
+        highs.getInfoValue("objective_function_value", obj);
+    };
+    double obj1, obj2;
+    run_once(obj1);
+    run_once(obj2);
+    REQUIRE(obj1 == Catch::Approx(obj2).epsilon(1e-12));
 }
 
 // ── Scylla parallel: opportunistic flag enables parallel pump chains ──


### PR DESCRIPTION
## Summary

- Add `kArmScylla` to the bandit portfolio and refactor the deterministic path to use `run_epoch_loop` via a new `PortfolioWorker` implementing `EpochWorker`
- Non-Scylla arms are stateless (one-shot per epoch, bandit reassigns); Scylla delegates to a lazy-init `PumpWorker` with persistent PDLP warm-start across epochs
- Mode dispatch: standalone Scylla after portfolio now only runs in opportunistic mode (deterministic portfolio includes it as an arm)

Closes #44

## Test plan

- [x] All 77 existing + new tests pass (including parallel execution)
- [x] New: `Portfolio: Scylla arm finds solution` on flugpl and egout
- [x] New: `Portfolio: Scylla-only single arm` — single-arm portfolio with only Scylla
- [x] New: `Portfolio deterministic: Scylla arm same result` — determinism verified
- [x] Updated "all arms disabled" edge-case tests to also disable Scylla

🤖 Generated with [Claude Code](https://claude.com/claude-code)